### PR TITLE
Fix: TypeError not raised, when getting len(Zr)

### DIFF
--- a/pypbc.c
+++ b/pypbc.c
@@ -1240,7 +1240,7 @@ Py_ssize_t  Element_len(PyObject *a) {
 	Element *py_ele = (Element*)a;
 	if (py_ele->group == Zr) {
 		PyErr_SetString(PyExc_TypeError, "Elements of type Zr have no len()");
-		return NULL;
+		return -1;
 	}
 	
 	// query the element dimension


### PR DESCRIPTION
Acording to the [docs](https://docs.python.org/3.8/extending/extending.html#intermezzo-errors-and-exceptions) a non-NULL value should be returned to indicate, that an exception occured. This also fixes the test cases running when executing `make test`.
